### PR TITLE
Fully switched to Unity's new input system

### DIFF
--- a/UrbanDriving/Assets/Samples/XR Interaction Toolkit/3.0.3/Starter Assets/XRI Default Input Actions.inputactions
+++ b/UrbanDriving/Assets/Samples/XR Interaction Toolkit/3.0.3/Starter Assets/XRI Default Input Actions.inputactions
@@ -707,7 +707,7 @@
                     "name": "Select",
                     "type": "Button",
                     "id": "33754c03-48ec-46ef-9bc6-22ed6bfdd8e8",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
@@ -725,7 +725,7 @@
                     "name": "Activate",
                     "type": "Button",
                     "id": "0c0991c5-d329-4afc-8892-1076b440477c",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
@@ -1503,7 +1503,7 @@
                     "name": "Select",
                     "type": "Button",
                     "id": "ac96c10b-c955-4a46-8e67-bf16bc069b53",
-                    "expectedControlType": "Button",
+                    "expectedControlType": "",
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
@@ -2763,7 +2763,173 @@
                     "isPartOfComposite": true
                 }
             ]
+        },
+        {
+            "name": "Car Controls",
+            "id": "098bda37-bfeb-49c3-b0a3-9de1228f5273",
+            "actions": [
+                {
+                    "name": "Gas Pedal",
+                    "type": "Value",
+                    "id": "e23c58c1-e66b-454a-ab55-02c6e6127d00",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Turn Wheel",
+                    "type": "Value",
+                    "id": "b718e879-8554-4af9-9179-d8f0f284a7b5",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Brake Pedal",
+                    "type": "Value",
+                    "id": "bc5fea77-1c0a-4c43-b9b2-58562edede19",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Gear State",
+                    "type": "Value",
+                    "id": "f423e441-fd88-42ab-8102-35b62dc0af6e",
+                    "expectedControlType": "Integer",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "Keyboard",
+                    "id": "b48f9a81-bc59-4755-9147-e0d9062fc123",
+                    "path": "1DAxis(whichSideWins=1)",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Gas Pedal",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "7231a09e-77c2-489e-8892-77749136be19",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Gas Pedal",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "f224aa1a-8fe2-4ba8-8c3c-873cbe34d683",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Gas Pedal",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "VR Controller",
+                    "id": "efa86303-761c-4057-8eae-92db9ed3f824",
+                    "path": "1DAxis(whichSideWins=1)",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Gas Pedal",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "fcb19443-2ab5-40e8-b303-7bbc3e11c149",
+                    "path": "<XRController>{LeftHand}/{Trigger}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Gas Pedal",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "83cddce5-cc87-4be3-b421-7c44aecf9697",
+                    "path": "<XRController>{RightHand}/{Trigger}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Gas Pedal",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "c144a174-8a0b-4549-8545-d371f2e56aa6",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Turn Wheel",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "4f891167-f6f7-4429-9b71-24504063a157",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Turn Wheel",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "9389539a-8226-43e3-a696-215c4946828b",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Turn Wheel",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "b97f3e79-bea9-4479-a645-c4d587fce227",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Brake Pedal",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
         }
     ],
-    "controlSchemes": []
+    "controlSchemes": [
+        {
+            "name": "PC Control",
+            "bindingGroup": "PC Control",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
 }

--- a/UrbanDriving/Assets/Scenes/game.unity
+++ b/UrbanDriving/Assets/Scenes/game.unity
@@ -922,7 +922,7 @@ MonoBehaviour:
     m_PostInfinity: 2
     m_RotationOrder: 4
   tireRotationAngle: 25
-  steeringStrengthCoefficient: 9000
+  steeringStrengthCoefficient: 6000
   enableAccelerationForce: 1
   axialFriction: 300
   accelerationForce: 6000
@@ -967,10 +967,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   steeringWheel: {fileID: 2626790061846938065}
   wheelKnob: {fileID: 1966930335}
-  leftHandTrigger: {fileID: -4289430672226363583, guid: c348712bda248c246b8c49b3db54643f, type: 3}
-  rightHandTrigger: {fileID: 7904272356298805229, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  gasPedal: {fileID: 6398678821623396951, guid: c348712bda248c246b8c49b3db54643f, type: 3}
+  wheelTurn: {fileID: -6240996045102080081, guid: c348712bda248c246b8c49b3db54643f, type: 3}
   steerTurnLimit: 150
-  isInVR: 1
 --- !u!1 &618025395
 GameObject:
   m_ObjectHideFlags: 0

--- a/UrbanDriving/Assets/Scripts/CarController.cs
+++ b/UrbanDriving/Assets/Scripts/CarController.cs
@@ -11,17 +11,17 @@ public class CarController : MonoBehaviour
     [SerializeField]
     private XRKnob wheelKnob;
     [SerializeField]
-    private InputActionReference leftHandTrigger;
+    private InputActionReference gasPedal;
     [SerializeField]
-    private InputActionReference rightHandTrigger;
-    [SerializeField]
-    private float steerTurnLimit = 150.0f;
-    [SerializeField]
+    private InputActionReference wheelTurn;
+    
     private bool isInVR = false;
     private float wheelAngle;
 
     void Awake()
     {
+        isInVR = UnityEngine.XR.XRSettings.enabled;
+        Debug.Log(isInVR);
         if (!isInVR)
         {
             wheelAngle = steeringWheel.localEulerAngles.x;
@@ -39,39 +39,17 @@ public class CarController : MonoBehaviour
     {
         if (!isInVR)
         {
-            if (Input.GetKey(KeyCode.A))
-            {
-                steeringWheel.localEulerAngles = new Vector3(wheelAngle, 0f, -steerTurnLimit);
-            }
-            else if (Input.GetKey(KeyCode.D))
-            {
-                steeringWheel.localEulerAngles = new Vector3(wheelAngle, 0f, steerTurnLimit);
-            }
-            else
-            {
-                steeringWheel.localEulerAngles = new Vector3(wheelAngle, 0f, 0f);
-            }
+            wheelKnob.value = (wheelTurn.action.ReadValue<float>() + 1.0f) / 2;
         }
     }
 
     public float GetWheelRelativeTurn()
     {
-        if (!isInVR)
-        {
-            if (steeringWheel.localEulerAngles.z > 180f)
-            {
-                return (steeringWheel.localEulerAngles.z -360f) / steerTurnLimit;
-            }
-            return steeringWheel.localEulerAngles.z / steerTurnLimit;
-        }
-        else
-        {
-            return (wheelKnob.value - 0.5f) * 2;
-        }
+        return (wheelKnob.value - 0.5f) * 2;
     }
 
     public float GetGasValue()
     {
-        return rightHandTrigger.action.ReadValue<float>() - leftHandTrigger.action.ReadValue<float>();
+        return gasPedal.action.ReadValue<float>();
     }
 }

--- a/UrbanDriving/ProjectSettings/ProjectSettings.asset
+++ b/UrbanDriving/ProjectSettings/ProjectSettings.asset
@@ -141,10 +141,7 @@ PlayerSettings:
   visionOSBundleVersion: 1.0
   tvOSBundleVersion: 1.0
   bundleVersion: 0.1
-  preloadedAssets:
-  - {fileID: -8196854396901781169, guid: 1a4c68ca72a83449f938d669337cb305, type: 2}
-  - {fileID: 11400000, guid: bfa1182bd221b4ca89619141f66f1260, type: 2}
-  - {fileID: -64324148185763206, guid: a9a6963505ddf7f4d886008c6dc86122, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1
@@ -933,7 +930,7 @@ PlayerSettings:
   hmiLogStartupTiming: 0
   hmiCpuConfiguration: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 2
+  activeInputHandler: 1
   windowsGamepadBackendHint: 0
   cloudProjectId: f93ed7b3-5bd4-4245-be09-64ebcfca20e1
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
The car controls now use Unity's new input actions.

This means that the car is now controllable both on PC and in VR.